### PR TITLE
[ECO-1441] Revise default candle times

### DIFF
--- a/src/frontend/src/components/trade/TVChartContainer.tsx
+++ b/src/frontend/src/components/trade/TVChartContainer.tsx
@@ -144,7 +144,8 @@ export const TVChartContainer: React.FC<
             `/candlesticks?${new URLSearchParams({
               market_id: `eq.${props.selectedMarket.market_id}`,
               resolution: `eq.${DAY_BY_RESOLUTION[resolution.toString()]}`,
-              and: `(start_time.lte.${toDateISOString},` +
+              and:
+                `(start_time.lte.${toDateISOString},` +
                 `start_time.gte.${fromDateISOString})`,
             })}`,
             API_URL,
@@ -313,19 +314,24 @@ export const TVChartContainer: React.FC<
       const endDaysAgo = 0;
       const startMilliseconds = now.getTime() - startDaysAgo * MS_IN_ONE_DAY;
       const endMilliseconds = now.getTime() - endDaysAgo * MS_IN_ONE_DAY;
-      const startTimestamp = Math.floor(new Date(startMilliseconds).getTime()) / 1000;
-      const endTimestamp = Math.floor(new Date(endMilliseconds).getTime()) / 1000;
+      const startTimestamp =
+        Math.floor(new Date(startMilliseconds).getTime()) / 1000;
+      const endTimestamp =
+        Math.floor(new Date(endMilliseconds).getTime()) / 1000;
 
-      chart.setVisibleRange({
-        from: startTimestamp,
-        to: endTimestamp
-      }).then(() => {
-        console.debug('Visible range applied!');
-        console.debug('from: ', new Date(startTimestamp * 1000));
-        console.debug('to:   ', new Date(endTimestamp * 1000));
-      }).catch(error => {
-        console.error('Error applying visible range:', error);
-      });
+      chart
+        .setVisibleRange({
+          from: startTimestamp,
+          to: endTimestamp,
+        })
+        .then(() => {
+          console.warn("Visible range applied!");
+          console.warn("from: ", new Date(startTimestamp * 1000));
+          console.warn("to:   ", new Date(endTimestamp * 1000));
+        })
+        .catch((error) => {
+          console.error("Error applying visible range:", error);
+        });
     });
 
     return () => {

--- a/src/frontend/src/components/trade/TVChartContainer.tsx
+++ b/src/frontend/src/components/trade/TVChartContainer.tsx
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import { useRouter } from "next/router";
-import { useState, useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 
 import { API_URL } from "@/env";
 import { type ApiMarket, type MarketData } from "@/types/api";
@@ -23,7 +23,6 @@ const DAY_BY_RESOLUTION: { [key: string]: string } = {
   "15": "900",
   "240": "14400",
   "3D": "43200",
-  "10": "600",
   "5": "300",
   "1": "60",
 };
@@ -38,7 +37,7 @@ const RED = "rgba(240, 129, 129, 1.0)";
 const GREEN_OPACITY_HALF = "rgba(110, 213, 163, 0.5)";
 const RED_OPACITY_HALF = "rgba(240, 129, 129, 0.5)";
 
-const resolutions = ["1", "5", "10", "15", "30", "60", "4H", "1D"];
+const resolutions = ["1", "5", "15", "30", "60", "4H", "1D"];
 
 const configurationData: DatafeedConfiguration = {
   supported_resolutions: resolutions,
@@ -320,6 +319,10 @@ export const TVChartContainer: React.FC<
       chart.setVisibleRange({
         from: startTimestamp,
         to: endTimestamp
+      }).then(() => {
+        console.debug('Visible range applied!');
+        console.debug('from: ', new Date(startTimestamp * 1000));
+        console.debug('to:   ', new Date(endTimestamp * 1000));
       }).catch(error => {
         console.error('Error applying visible range:', error);
       });


### PR DESCRIPTION
Updating the TradingView widget to confine data shown to the past day and set the initial timeframe to 5m.

Also cleaned up the fetch request code a little.