### PR TITLE
[ECO-1459] Change small screen suggestion message

### DIFF
--- a/src/frontend/src/components/StatsBar.tsx
+++ b/src/frontend/src/components/StatsBar.tsx
@@ -190,10 +190,11 @@ export const StatsBar: React.FC<{
       </BaseModal>
       {isModalOpen && isSmallWindow && (
         <div
-          className={`fixed inset-0 z-[60] flex h-full w-full items-center justify-center overflow-hidden bg-black text-center font-jost text-3xl font-bold text-white`}
+          className={`fixed inset-0 z-[60] flex h-full w-full items-center justify-center overflow-hidden bg-black text-center font-jost text-2xl font-bold text-white`}
         >
-          💩 <br />
-          View on Larger Screen
+          For the best experience,
+          <br />
+          please use a larger screen.
         </div>
       )}
       <div className="hidden justify-between border-b border-neutral-600 px-[29.19px] py-3 md:flex lg:pr-[46.24px]">


### PR DESCRIPTION
Currently, the message has an emoji and uses inconsistent capitalization.

Change it to "For the best experience, please use a larger screen."

![image](https://github.com/econia-labs/econia-frontend/assets/90358481/e98e0778-ee3b-4a3f-9f52-f335c67f5f87)
![image](https://github.com/econia-labs/econia-frontend/assets/90358481/9320990f-18fe-4227-922d-0d6c5b3f0c3b)
