### PR TITLE
[ECO-1463] Resolve candlestick upper bound time query issue

### DIFF
--- a/src/frontend/src/components/trade/TVChartContainer.tsx
+++ b/src/frontend/src/components/trade/TVChartContainer.tsx
@@ -147,7 +147,6 @@ export const TVChartContainer: React.FC<
             queryParams,
             start: new Date(from * 1000),
             end: new Date(to * 1000),
-            fetchDelay: 0,
           });
           if (data.length < 1) {
             onHistoryCallback([], {

--- a/src/frontend/src/components/trade/TVChartContainer.tsx
+++ b/src/frontend/src/components/trade/TVChartContainer.tsx
@@ -2,10 +2,10 @@
 import { useRouter } from "next/router";
 import { useEffect, useMemo, useRef } from "react";
 
-import { API_URL } from "@/env";
 import { type ApiMarket, type MarketData } from "@/types/api";
 import { toDecimalPrice, toDecimalSize } from "@/utils/econia";
-import { getClientTimezone } from "@/utils/helpers";
+import { getAllDataInTimeRange, getClientTimezone } from "@/utils/helpers";
+
 //eslint-disable-next-line
 let chartModule: any = {} as any;
 (() => {
@@ -138,20 +138,17 @@ export const TVChartContainer: React.FC<
       ) => {
         const { from, to } = periodParams;
         try {
-          const toDateISOString = new Date(to * 1000).toISOString();
-          const fromDateISOString = new Date(from * 1000).toISOString();
-          const url = new URL(
-            `/candlesticks?${new URLSearchParams({
-              market_id: `eq.${props.selectedMarket.market_id}`,
-              resolution: `eq.${DAY_BY_RESOLUTION[resolution.toString()]}`,
-              and:
-                `(start_time.lte.${toDateISOString},` +
-                `start_time.gte.${fromDateISOString})`,
-            })}`,
-            API_URL,
-          ).href;
-          const res = await fetch(url);
-          const data = await res.json();
+          const queryParams = new URLSearchParams({
+            market_id: `eq.${props.selectedMarket.market_id}`,
+            resolution: `eq.${DAY_BY_RESOLUTION[resolution.toString()]}`,
+          });
+          const data = await getAllDataInTimeRange({
+            queryName: "candlesticks",
+            queryParams,
+            start: new Date(from * 1000),
+            end: new Date(to * 1000),
+            fetchDelay: 0,
+          });
           if (data.length < 1) {
             onHistoryCallback([], {
               noData: true,

--- a/src/frontend/src/constants.ts
+++ b/src/frontend/src/constants.ts
@@ -63,3 +63,5 @@ export const MAINNET_TOKEN_LIST: RawCoinInfo[] = [
     return coin;
   }),
 ];
+
+export const MAX_ELEMENTS_PER_FETCH = 100;

--- a/src/frontend/src/utils/helpers.ts
+++ b/src/frontend/src/utils/helpers.ts
@@ -121,7 +121,7 @@ export function getClientTimezone() {
 }
 
 /**
- * Helper function to auto-paginate queries for an nodeinfra endpoint
+ * Helper function to auto-paginate queries for a DSS REST API endpoint
  * until all of the data from a timeframe is returned.
  * Since this function's data will likely be used for frontend charting, it's
  * written with non-blocking pseudo-recursive setTimeout calls to avoid


### PR DESCRIPTION
This fix is warranted because the TradingView `charting_library` [datafeed API](https://www.tradingview.com/charting-library-docs/latest/connecting_data/Datafeed-API) explicitly expects all of the data included when a range is specified. See [here](https://www.tradingview.com/charting-library-docs/v26/connecting_data/Datafeed-API/#:~:text=Your%20response%20should%20always%20include%20all%20the%20existing%20data%20for%20the%20requested%20range.)

With our DSS, the API we're calling returns a max 100 data points. It does not ensure that all of the data within a time frame is returned. This means that the datafeed API thinks it's getting all of the data when it in fact is not.

Our API endpoint returns a max 100 candles starting from the `start` point in time meaning it ignores any data past the first 100 candles.

To fix this, I've added non-blocking pseudo-recursive `setTimeout` calls to fetch all data from a requested timeframe exhaustively.

Note that the fetching functionality implemented in #217 will be refactored to use this helper function since this is a better way to implement pagination.