### PR TITLE
[ECO-1474] Fix market account map error on wallet disconnect

### DIFF
--- a/src/frontend/src/components/AccountDetailsModal.tsx
+++ b/src/frontend/src/components/AccountDetailsModal.tsx
@@ -72,7 +72,7 @@ export const AccountDetailsModal: React.FC<{
       if (!account?.address) return null;
       try {
         const response = await fetch(
-          `${API_URL}/user_balances?select=*,markets(*)&user=eq.${account.address}`,
+          `${API_URL}/user_balances?select=*,markets(*)&address=eq.${account.address}`,
         );
         const data = await response.json();
         return data;


### PR DESCRIPTION
When you disconnect your wallet from the reference frontend website, it errors out because of an error with market account data. Fixing this will resolve that error.

The reason it errors is simply because the `user_balances` uses `address` instead of `user` now.