### PR TITLE
[ECO-1489] Enable SSR for dynamic imports with fallback and explanation

### DIFF
--- a/src/frontend/src/components/trade/TVChartContainer.tsx
+++ b/src/frontend/src/components/trade/TVChartContainer.tsx
@@ -14,8 +14,15 @@ import { type ApiMarket, type MarketData } from "@/types/api";
 import { toDecimalPrice, toDecimalSize } from "@/utils/econia";
 import { getAllDataInTimeRange, getClientTimezone } from "@/utils/helpers";
 
-/* eslint-disable-next-line  @typescript-eslint/no-var-requires */
-const ChartingLibrary = require("../../../public/static/charting_library");
+let ChartingLibrary: any = undefined;
+(() => {
+  try {
+    /* eslint-disable-next-line  @typescript-eslint/no-var-requires */
+    ChartingLibrary = require("../../../public/static/charting_library");
+  } catch (e) {
+    //
+  }
+})();
 const { widget } = ChartingLibrary;
 
 export interface ChartContainerProps {

--- a/src/frontend/src/components/trade/TVChartContainer.tsx
+++ b/src/frontend/src/components/trade/TVChartContainer.tsx
@@ -14,16 +14,9 @@ import { type ApiMarket, type MarketData } from "@/types/api";
 import { toDecimalPrice, toDecimalSize } from "@/utils/econia";
 import { getAllDataInTimeRange, getClientTimezone } from "@/utils/helpers";
 
-//eslint-disable-next-line
-let chartModule: any = {} as any;
-(() => {
-  try {
-    chartModule = require("../../../public/static/charting_library");
-  } catch (e) {
-    console.warn(e);
-  }
-})();
-const { widget } = chartModule;
+/* eslint-disable-next-line  @typescript-eslint/no-var-requires */
+const ChartingLibrary = require("../../../public/static/charting_library");
+const { widget } = ChartingLibrary;
 
 export interface ChartContainerProps {
   symbol: string;

--- a/src/frontend/src/pages/market/[market_id].tsx
+++ b/src/frontend/src/pages/market/[market_id].tsx
@@ -32,17 +32,18 @@ const ChartContainer: any = dynamic(
   () => {
     try {
       // We call `require` here for the private charting library before
-      // conditionally rendering the alternative charting component.
+      // to facilitate SSR with a fallback to the lightweight library.
       // If the import fails, the `catch` block is executed and we
       // load the `LightweightChartsContainer` instead.
       // If the library is present, the TVChartContainer component will
-      // just load the module from the cache with its `require(...)`.
+      // be used, and it will load the `charting_library` module from the
+      // cache with its `require(...)`.
       //
       // NOTE: We must use `require` here instead of a dynamic `import`
-      // to circumvent the build process failing due to an invalid path.
-      // Despite the fact that the path is statically resolved at build time
-      // in both cases, only `import` will cause the build to fail, whereas
-      // an invalid path supplied to `require` will not.
+      // to circumvent the SSR build process failing due to an invalid path.
+      // With `import` the provided path is statically resolved at build time
+      // whereas with `require`, path resolution is deferred until runtime and can
+      // thus be conditionally resolved within a `try/catch` block.
       require("../../../public/static/charting_library");
       return import("@/components/trade/TVChartContainer").then(
         (mod) => mod.TVChartContainer,

--- a/src/frontend/src/pages/market/[market_id].tsx
+++ b/src/frontend/src/pages/market/[market_id].tsx
@@ -28,7 +28,7 @@ type PathParams = {
   market_id: string;
 };
 
-const ChartContainer: any = dynamic(
+const ChartContainer = dynamic(
   () => {
     try {
       // We call `require` here for the private charting library before


### PR DESCRIPTION
The reference frontend code uses dynamic imports to facilitate ease of use for downstream developers to use the repo easily without having to fiddle with config options.

To continue to leverage SSR but not load unnecessary modules, we conditionally try  to import `charting_library`, and if it fails, we load the `lightweight-charts` library (and the corresponding component).

I've added a comment explaining how this works where the conditional component render is used.