### PR TITLE
[EOC-1538] Fix markdown render for env variables table

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,9 @@ To deploy on Vercel, you'll need to set up the following environment variables:
 | `NEXT_PUBLIC_READ_ONLY`                  | Config read only mode, 1 OR 0                                                                    |
 | `NEXT_PUBLIC_READ_ONLY_MESSAGE`          | Error message when user attempt do a require sign operator                                       |
 | `NEXT_PUBLIC_DEFAULT_MARKET_ID`          | Default market id                                                                                |
-| `NEXT_PUBLIC_INTEGRATOR_ADDRESS`         | The address that will receive integrator fees for taker orders. This address must have a fee     |
-|                                          | store registered for the given market                                                            |
+| `NEXT_PUBLIC_INTEGRATOR_ADDRESS`         | The address that will receive integrator fees for taker orders. This address must have a fee store registered for the given market |
 | `TRY_CLONING_TRADINGVIEW`                | Set `TRY_CLONING_TRADINGVIEW` to any value other than "1" to skip private submodule cloning      |
+
 
 The variables above will be added into the Vercel project, you can find them at the file `.env.example` or `.env.local` which you created from previous steps. However, the `GITHUB_ACCESS_TOKEN` is still missing, you have to create on your own.
 


### PR DESCRIPTION
Simple fix to make the markdown table only use one row instead of multiple