### PR TITLE
[ECO-1541] Fix typos and make consistent with the docs README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,14 +88,14 @@ To deploy on Vercel, you'll need to set up the following environment variables:
 | `NEXT_PUBLIC_FAUCET_ADDR`                | The Econia faucet address                                                                        |
 | `NEXT_PUBLIC_NETWORK_NAME`               | The network name (for example, testnet)                                                          |
 | `NEXT_PUBLIC_API_URL`                    | The Econia REST API URL                                                                          |
-| `NEXT_PUBLIC_RPC_NODE_URL`               | Aptos RPC url                                                                                    |
+| `NEXT_PUBLIC_RPC_NODE_URL`               | Aptos RPC URL                                                                                    |
 | `GITHUB_ACCESS_TOKEN`                    | Access token for GitHub account with private `TradingView` repo access (only required in Vercel) |
-| `NEXT_PUBLIC_UNCONNECTED_NOTICE_MESSAGE` | Message that show in modal when user have not connected wallet yet                               |
+| `NEXT_PUBLIC_UNCONNECTED_NOTICE_MESSAGE` | Message that shows in modal when user has not connected wallet yet                               |
 | `NEXT_PUBLIC_READ_ONLY`                  | Config read only mode, 1 OR 0                                                                    |
 | `NEXT_PUBLIC_READ_ONLY_MESSAGE`          | Error message when user attempt do a require sign operator                                       |
 | `NEXT_PUBLIC_DEFAULT_MARKET_ID`          | Default market id                                                                                |
 | `NEXT_PUBLIC_INTEGRATOR_ADDRESS`         | The address that will receive integrator fees for taker orders. This address must have a fee store registered for the given market |
-| `TRY_CLONING_TRADINGVIEW`                | Set `TRY_CLONING_TRADINGVIEW` to any value other than "1" to skip private submodule cloning      |
+| `TRY_CLONING_TRADINGVIEW`                | Set to any value other than "1" to skip private submodule cloning                                |
 
 
 The variables above will be added into the Vercel project, you can find them at the file `.env.example` or `.env.local` which you created from previous steps. However, the `GITHUB_ACCESS_TOKEN` is still missing, you have to create on your own.

--- a/README.md
+++ b/README.md
@@ -82,20 +82,20 @@ pnpm run dev
 
 To deploy on Vercel, you'll need to set up the following environment variables:
 
-| Variable                                 | Meaning                                                                                          |
-| ---------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| `NEXT_PUBLIC_ECONIA_ADDR`                | The Econia module address                                                                        |
-| `NEXT_PUBLIC_FAUCET_ADDR`                | The Econia faucet address                                                                        |
-| `NEXT_PUBLIC_NETWORK_NAME`               | The network name (for example, "mainnet" or "testnet")                                           |
-| `NEXT_PUBLIC_API_URL`                    | The Econia REST API URL                                                                          |
-| `NEXT_PUBLIC_RPC_NODE_URL`               | Aptos RPC URL                                                                                    |
-| `GITHUB_ACCESS_TOKEN`                    | Access token for the GitHub account with access to the private `TradingView` repo. This is required when deploying to Vercel |
-| `NEXT_PUBLIC_UNCONNECTED_NOTICE_MESSAGE` | The modal message to display when a user has not connected their wallet yet                      |
-| `NEXT_PUBLIC_READ_ONLY`                  | Set to read-only mode, where "1" means the user can't submit or sign transactions and "0" means they can |
-| `NEXT_PUBLIC_READ_ONLY_MESSAGE`          | The error message displayed to a user when they attempt to sign a transaction in read-only mode  |
-| `NEXT_PUBLIC_DEFAULT_MARKET_ID`          | Default market id                                                                                |
+| Variable                                 | Meaning                                                                                                                            |
+| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `NEXT_PUBLIC_ECONIA_ADDR`                | The Econia module address                                                                                                          |
+| `NEXT_PUBLIC_FAUCET_ADDR`                | The Econia faucet address                                                                                                          |
+| `NEXT_PUBLIC_NETWORK_NAME`               | The network name (for example, "mainnet" or "testnet")                                                                             |
+| `NEXT_PUBLIC_API_URL`                    | The Econia REST API URL                                                                                                            |
+| `NEXT_PUBLIC_RPC_NODE_URL`               | Aptos RPC URL                                                                                                                      |
+| `GITHUB_ACCESS_TOKEN`                    | Access token for the GitHub account with access to the private `TradingView` repo. This is required when deploying to Vercel       |
+| `NEXT_PUBLIC_UNCONNECTED_NOTICE_MESSAGE` | The modal message to display when a user has not connected their wallet yet                                                        |
+| `NEXT_PUBLIC_READ_ONLY`                  | Set to read-only mode, where "1" means the user can't submit or sign transactions and "0" means they can                           |
+| `NEXT_PUBLIC_READ_ONLY_MESSAGE`          | The error message displayed to a user when they attempt to sign a transaction in read-only mode                                    |
+| `NEXT_PUBLIC_DEFAULT_MARKET_ID`          | Default market id                                                                                                                  |
 | `NEXT_PUBLIC_INTEGRATOR_ADDRESS`         | The address that will receive integrator fees for taker orders. This address must have a fee store registered for the given market |
-| `TRY_CLONING_TRADINGVIEW`                | Set to any value other than "1" to skip private submodule cloning                                |
+| `TRY_CLONING_TRADINGVIEW`                | Set to any value other than "1" to skip private submodule cloning                                                                  |
 
 
 The variables above will be added into the Vercel project, you can find them at the file `.env.example` or `.env.local` which you created from previous steps. However, the `GITHUB_ACCESS_TOKEN` is still missing, you have to create on your own.

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ To deploy on Vercel, you'll need to set up the following environment variables:
 | `NEXT_PUBLIC_API_URL`                    | The Econia REST API URL                                                                          |
 | `NEXT_PUBLIC_RPC_NODE_URL`               | Aptos RPC URL                                                                                    |
 | `GITHUB_ACCESS_TOKEN`                    | Access token for GitHub account with private `TradingView` repo access (only required in Vercel) |
-| `NEXT_PUBLIC_UNCONNECTED_NOTICE_MESSAGE` | Message that shows in modal when user has not connected wallet yet                               |
+| `NEXT_PUBLIC_UNCONNECTED_NOTICE_MESSAGE` | The modal message to display when a user has not connected their wallet yet                      |
 | `NEXT_PUBLIC_READ_ONLY`                  | Config read only mode, 1 OR 0                                                                    |
 | `NEXT_PUBLIC_READ_ONLY_MESSAGE`          | Error message when user attempt do a require sign operator                                       |
 | `NEXT_PUBLIC_DEFAULT_MARKET_ID`          | Default market id                                                                                |

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ To deploy on Vercel, you'll need to set up the following environment variables:
 | `NEXT_PUBLIC_RPC_NODE_URL`               | Aptos RPC URL                                                                                                                      |
 | `GITHUB_ACCESS_TOKEN`                    | Access token for the GitHub account with access to the private `TradingView` repo. This is required when deploying to Vercel       |
 | `NEXT_PUBLIC_UNCONNECTED_NOTICE_MESSAGE` | The modal message to display when a user has not connected their wallet yet                                                        |
-| `NEXT_PUBLIC_READ_ONLY`                  | Set to read-only mode, where "1" means the user can't submit or sign transactions and "0" means they can                           |
+| `NEXT_PUBLIC_READ_ONLY`                  | For setting read-only mode, where "1" means the user can't submit or sign transactions and "0" means they can                      |
 | `NEXT_PUBLIC_READ_ONLY_MESSAGE`          | The error message displayed to a user when they attempt to sign a transaction in read-only mode                                    |
 | `NEXT_PUBLIC_DEFAULT_MARKET_ID`          | Default market id                                                                                                                  |
 | `NEXT_PUBLIC_INTEGRATOR_ADDRESS`         | The address that will receive integrator fees for taker orders. This address must have a fee store registered for the given market |

--- a/README.md
+++ b/README.md
@@ -84,15 +84,15 @@ To deploy on Vercel, you'll need to set up the following environment variables:
 
 | Variable                                 | Meaning                                                                                          |
 | ---------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| `NEXT_PUBLIC_ECONIA_ADDR`                | The Econia address                                                                               |
+| `NEXT_PUBLIC_ECONIA_ADDR`                | The Econia module address                                                                        |
 | `NEXT_PUBLIC_FAUCET_ADDR`                | The Econia faucet address                                                                        |
-| `NEXT_PUBLIC_NETWORK_NAME`               | The network name (for example, testnet)                                                          |
+| `NEXT_PUBLIC_NETWORK_NAME`               | The network name (for example, "mainnet" or "testnet")                                           |
 | `NEXT_PUBLIC_API_URL`                    | The Econia REST API URL                                                                          |
 | `NEXT_PUBLIC_RPC_NODE_URL`               | Aptos RPC URL                                                                                    |
-| `GITHUB_ACCESS_TOKEN`                    | Access token for GitHub account with private `TradingView` repo access (only required in Vercel) |
+| `GITHUB_ACCESS_TOKEN`                    | Access token for the GitHub account with access to the private `TradingView` repo. This is required when deploying to Vercel |
 | `NEXT_PUBLIC_UNCONNECTED_NOTICE_MESSAGE` | The modal message to display when a user has not connected their wallet yet                      |
-| `NEXT_PUBLIC_READ_ONLY`                  | Config read only mode, 1 OR 0                                                                    |
-| `NEXT_PUBLIC_READ_ONLY_MESSAGE`          | Error message when user attempt do a require sign operator                                       |
+| `NEXT_PUBLIC_READ_ONLY`                  | Set to read-only mode, where "1" means the user can't submit or sign transactions and "0" means they can |
+| `NEXT_PUBLIC_READ_ONLY_MESSAGE`          | The error message displayed to a user when they attempt to sign a transaction in read-only mode  |
 | `NEXT_PUBLIC_DEFAULT_MARKET_ID`          | Default market id                                                                                |
 | `NEXT_PUBLIC_INTEGRATOR_ADDRESS`         | The address that will receive integrator fees for taker orders. This address must have a fee store registered for the given market |
 | `TRY_CLONING_TRADINGVIEW`                | Set to any value other than "1" to skip private submodule cloning                                |


### PR DESCRIPTION
This also makes the frontend `README.md` consistent with the docs