### PR TITLE
[ECO 1705] Fix lightweight-charts implementation to reflect market ID changing

### DIFF
--- a/src/frontend/src/components/trade/LightweightChartsContainer.tsx
+++ b/src/frontend/src/components/trade/LightweightChartsContainer.tsx
@@ -8,19 +8,13 @@ import {
   VOLUME_PRICE_CHART_ID,
 } from "@/constants";
 import { type DAY_BY_RESOLUTION, useChartData } from "@/hooks/useChartData";
-import { type ApiMarket } from "@/types/api";
+import {
+  type ChartContainerProps,
+  type TVChartContainerProps,
+} from "@/pages/market/[market_id]";
 
 import ResizeChartButton from "./ResizeChartButton";
 import ResolutionSelector from "./ResolutionSelector";
-
-export interface ChartContainerProps {
-  symbol: string;
-}
-
-export type TVChartContainerProps = {
-  selectedMarket: ApiMarket;
-  allMarketData: ApiMarket[];
-};
 
 export const LightweightChartsContainer: React.FC<
   Partial<ChartContainerProps> & TVChartContainerProps

--- a/src/frontend/src/components/trade/TVChartContainer.tsx
+++ b/src/frontend/src/components/trade/TVChartContainer.tsx
@@ -10,6 +10,10 @@ import {
   TV_CHARTING_LIBRARY_RESOLUTIONS,
 } from "@/constants";
 import { DAY_BY_RESOLUTION, MS_IN_ONE_DAY } from "@/hooks/useChartData";
+import {
+  type ChartContainerProps,
+  type TVChartContainerProps,
+} from "@/pages/market/[market_id]";
 import { type ApiMarket, type MarketData } from "@/types/api";
 import { toDecimalPrice, toDecimalSize } from "@/utils/econia";
 import { getAllDataInTimeRange, getClientTimezone } from "@/utils/helpers";
@@ -26,10 +30,6 @@ let ChartingLibrary: any = undefined;
 })();
 const { widget } = ChartingLibrary;
 
-export interface ChartContainerProps {
-  symbol: string;
-}
-
 const configurationData: DatafeedConfiguration = {
   supported_resolutions: TV_CHARTING_LIBRARY_RESOLUTIONS,
   symbols_types: [
@@ -38,11 +38,6 @@ const configurationData: DatafeedConfiguration = {
       value: "crypto",
     },
   ],
-};
-
-type TVChartContainerProps = {
-  selectedMarket: ApiMarket;
-  allMarketData: ApiMarket[];
 };
 
 export const TVChartContainer: React.FC<


### PR DESCRIPTION
 - [x] Fix the chart not fetching data when switching market IDs
 - [x] Store market data per ID, not per instance of a chart
 - [x] Allow the ability to force load lightweight charts with the query param `&lwc=true` for testing purposes
 - [x] Allow the additional `lwc` query param to force the app to use the lightweights chart implementation even if the private one is available
 
 Example for using `lwc`:
   - `http://localhost:3000/market/8?lwc=true`
   - `https://econia-frontend.vercel.app/market/8?lwc=true`
 